### PR TITLE
replaced parameter value in example code

### DIFF
--- a/boruta/boruta_py.py
+++ b/boruta/boruta_py.py
@@ -150,7 +150,7 @@ class BorutaPy(BaseEstimator, TransformerMixin):
     
     # define random forest classifier, with utilising all cores and
     # sampling in proportion to y labels
-    rf = RandomForestClassifier(n_jobs=-1, class_weight='auto', max_depth=5)
+    rf = RandomForestClassifier(n_jobs=-1, class_weight='balanced', max_depth=5)
     
     # define Boruta feature selection method
     feat_selector = BorutaPy(rf, n_estimators='auto', verbose=2, random_state=1)


### PR DESCRIPTION
Replaced parameter value 'auto' in example code with 'balanced' which is a valid value (consistenly with pull request in the README.md file)
` rf = RandomForestClassifier(n_jobs=-1, class_weight='balanced', max_depth=5)`